### PR TITLE
Fix async file existence check

### DIFF
--- a/server/utils/multimodal-processor.ts
+++ b/server/utils/multimodal-processor.ts
@@ -19,7 +19,16 @@ import crypto from 'crypto';
 import * as gcsClient from './gcs-client';
 
 const readFileAsync = promisify(fs.readFile);
-const existsAsync = promisify(fs.exists);
+// fs.exists does not follow the Node callback convention, so promisify will
+// mis-handle its boolean argument. Use fs.promises.access instead.
+const existsAsync = async (filePath: string): Promise<boolean> => {
+  try {
+    await fs.promises.access(filePath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+};
 const unlinkAsync = promisify(fs.unlink);
 const writeFileAsync = promisify(fs.writeFile);
 

--- a/server/utils/multimodal-processor.ts.bak
+++ b/server/utils/multimodal-processor.ts.bak
@@ -19,7 +19,16 @@ import crypto from 'crypto';
 import * as gcsClient from './gcs-client';
 
 const readFileAsync = promisify(fs.readFile);
-const existsAsync = promisify(fs.exists);
+// fs.exists uses a non-standard callback, so util.promisify would reject with
+// the boolean "exists" value. Implement a safe promise-based check instead.
+const existsAsync = async (filePath: string): Promise<boolean> => {
+  try {
+    await fs.promises.access(filePath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+};
 const unlinkAsync = promisify(fs.unlink);
 const writeFileAsync = promisify(fs.writeFile);
 

--- a/server/utils/multimodal-processor.ts.new
+++ b/server/utils/multimodal-processor.ts.new
@@ -19,7 +19,14 @@ import crypto from 'crypto';
 import * as gcsClient from './gcs-client';
 
 const readFileAsync = promisify(fs.readFile);
-const existsAsync = promisify(fs.exists);
+const existsAsync = async (filePath: string): Promise<boolean> => {
+  try {
+    await fs.promises.access(filePath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+};
 const unlinkAsync = promisify(fs.unlink);
 const writeFileAsync = promisify(fs.writeFile);
 


### PR DESCRIPTION
## Summary
- fix file existence checks in `multimodal-processor` utilities

## Testing
- `./run-tests.sh` *(fails: EHOSTUNREACH to registry.npmjs.org)*