### PR TITLE
fix: prevent listener leak in useToast

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure `useToast` adds its listener only once

## Testing
- `./run-tests.sh` *(fails: npm err EHOSTUNREACH)*