### PR TITLE
[server/auth] use doubleCsrf token generation

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -377,24 +377,13 @@ export function configureAuth(app: any) {
   // Endpoint to get CSRF token (with rate limiting)
   app.get('/api/csrf-token', csrfRateLimiter, (req: Request, res: Response) => {
     try {
-      // Generate a secure token using native crypto module
-      import('crypto').then(crypto => {
-        const token = crypto.randomBytes(32).toString('hex');
-        return res.json({ csrfToken: token });
-      }).catch(error => {
-        console.error('Error importing crypto module - this is a critical security failure:', error);
-        // No fallback - if crypto is unavailable, we can't generate secure tokens
-        return res.status(500).json({ 
-          error: 'Unable to generate secure token',
-          message: 'Server security configuration error'
-        });
-      });
+      const token = csrfProtection.generateCsrfToken(req, res);
+      return res.json({ csrfToken: token });
     } catch (error: any) {
       console.error('Error generating CSRF token - this is a critical security failure:', error);
-      // No fallback - if we can't generate secure tokens, we must fail closed
-      return res.status(500).json({ 
+      return res.status(500).json({
         error: 'Critical security error',
-        message: 'Unable to generate secure token' 
+        message: 'Unable to generate secure token'
       });
     }
   });


### PR DESCRIPTION
## Summary
- use `csrfProtection.generateCsrfToken` for `/api/csrf-token`
- mock `csrf-csrf` token storage in tests
- add route and test to verify that CSRF tokens from the endpoint are accepted

## Testing
- `./test/run-tests.sh unit` *(fails: request to https://registry.npmjs.org/vitest failed, reason: connect EHOSTUNREACH)*
- `./test/run-tests.sh integration` *(fails: request to https://registry.npmjs.org/vitest failed, reason: connect EHOSTUNREACH)*