### PR TITLE
[server/utils] enforce URL host allowlist

### DIFF
--- a/test/unit/multimodal-processor.test.js
+++ b/test/unit/multimodal-processor.test.js
@@ -68,10 +68,10 @@ describe('Multimodal Processor Utilities', () => {
       fetch.mockResolvedValue(mockResponse);
       
       // Call function
-      const result = await downloadFromUrl('https://example.com/file.pdf');
+      const result = await downloadFromUrl('https://storage.googleapis.com/test-bucket/file.pdf');
       
       // Verify results
-      expect(fetch).toHaveBeenCalledWith('https://example.com/file.pdf');
+      expect(fetch).toHaveBeenCalledWith('https://storage.googleapis.com/test-bucket/file.pdf');
       expect(fs.promises.writeFile).toHaveBeenCalled();
       expect(result.buffer).toBeInstanceOf(Buffer);
       expect(result.localPath).toContain('.pdf');
@@ -87,7 +87,7 @@ describe('Multimodal Processor Utilities', () => {
       fetch.mockRejectedValue(new Error('Network error'));
       
       // Verify error handling
-      await expect(downloadFromUrl('https://example.com/file.pdf')).rejects.toThrow();
+      await expect(downloadFromUrl('https://storage.googleapis.com/test-bucket/file.pdf')).rejects.toThrow();
     });
     
     it('should handle HTTP error responses', async () => {
@@ -98,9 +98,14 @@ describe('Multimodal Processor Utilities', () => {
         statusText: 'Not Found'
       };
       fetch.mockResolvedValue(mockResponse);
-      
+
       // Verify error handling
-      await expect(downloadFromUrl('https://example.com/file.pdf')).rejects.toThrow('Failed to download file: 404 Not Found');
+      await expect(downloadFromUrl('https://storage.googleapis.com/test-bucket/file.pdf')).rejects.toThrow('Failed to download file: 404 Not Found');
+    });
+
+    it('should reject URLs from disallowed hosts', async () => {
+      await expect(downloadFromUrl('https://malicious.com/file.pdf')).rejects.toThrow('Disallowed host');
+      expect(fetch).not.toHaveBeenCalled();
     });
   });
   
@@ -128,10 +133,10 @@ describe('Multimodal Processor Utilities', () => {
       fetch.mockResolvedValue(mockResponse);
       
       // Call function with URL
-      const result = await processFileForMultimodal('https://example.com/image.jpg', 'image.jpg', 'image/jpeg');
+      const result = await processFileForMultimodal('https://storage.googleapis.com/test-bucket/image.jpg', 'image.jpg', 'image/jpeg');
       
       // Verify downloads happened
-      expect(fetch).toHaveBeenCalledWith('https://example.com/image.jpg');
+      expect(fetch).toHaveBeenCalledWith('https://storage.googleapis.com/test-bucket/image.jpg');
       expect(fs.promises.writeFile).toHaveBeenCalled();
       
       // Verify file was processed after download


### PR DESCRIPTION
## Summary
- enforce allowed host validation in `downloadFromUrl`
- add allowlist helper functions
- update `multimodal-processor` unit tests with allowed and disallowed host cases

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run check` *(fails: TypeScript errors)*
- `./test/run-tests.sh unit` *(fails: EHOSTUNREACH to registry)*
