### PR TITLE
[server] add learning-science phrasing to system prompt

### DIFF
--- a/server/services/ai-service.ts
+++ b/server/services/ai-service.ts
@@ -181,14 +181,14 @@ ${params.studentSubmissionContent}
 
       // Create a system prompt for text submissions
       const systemPrompt = `You are an expert AI Teaching Assistant analyzing a text-based submission.
-Your task is to provide precise, detailed, and constructive feedback on the student's work.
+Your task is to deliver concise, actionable feedback linked to the rubric and learning objectives.
 
-Your feedback should be:
-- Specific and reference exact elements in the submission
-- Constructive and actionable
-- Balanced, noting both strengths and areas for improvement
-- Free of personal opinions or bias
-- Focused on helping the student improve
+Your feedback should:
+- Cite specific elements in the submission with references to rubric criteria
+- Encourage the student to reflect on how they might revise their work
+- Highlight progress made and areas for continued practice
+- Remain constructive, balanced, and free of personal bias
+- Focus on helping the student grow and improve
 
 Respond ONLY with valid, complete JSON matching the requested structure.
 Do not include explanatory text, comments, or markdown outside the JSON object.`;


### PR DESCRIPTION
## Summary
- infuse learning-science language into AI service system prompt

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run typecheck` *(fails: Missing script)*
- `npm run check` *(fails: type errors)*