### PR TITLE
[client] add global error boundary

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { Switch, Route, Redirect } from "wouter";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -6,7 +5,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { MITNavbar } from "@/components/layout/mit-navbar";
 import { MITFooter } from "@/components/layout/mit-footer";
-import { ErrorBoundary } from "@/components/ui/error-boundary";
+import GlobalErrorBoundary from "@/components/layout/global-error-boundary";
 import NotFound from "@/pages/not-found";
 import Login from "@/pages/login-fixed";
 import Dashboard from "@/pages/dashboard";
@@ -170,11 +169,7 @@ function Router() {
 }
 
 function App() {
-  // Function to log errors to monitoring service
-  const handleError = (error: Error, errorInfo: React.ErrorInfo): void => {
-    // In production, you would send this to an error monitoring service
-    console.error('Error caught by error boundary:', error, errorInfo);
-  };
+  // Function to log errors if needed. GlobalErrorBoundary will handle logging by default.
   
   // Auth0 logout redirect is handled in AuthProvider
   
@@ -186,9 +181,9 @@ function App() {
             <MITNavbar />
             <main className="flex-grow">
               <Toaster />
-              <ErrorBoundary onError={handleError}>
+              <GlobalErrorBoundary>
                 <Router />
-              </ErrorBoundary>
+              </GlobalErrorBoundary>
             </main>
             <MITFooter />
           </div>

--- a/client/src/components/layout/global-error-boundary.tsx
+++ b/client/src/components/layout/global-error-boundary.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+import { ErrorBoundary } from '@/components/ui/error-boundary';
+import ErrorPage from '@/pages/error';
+
+interface GlobalErrorBoundaryProps {
+  children: ReactNode;
+}
+
+/**
+ * Global error boundary to catch unexpected errors across the application.
+ * Displays a friendly error page instead of leaving the UI blank.
+ */
+export default function GlobalErrorBoundary({ children }: GlobalErrorBoundaryProps) {
+  const handleError = (error: Error, info: React.ErrorInfo): void => {
+    // In production, send this information to an error monitoring service
+    console.error('Global error caught:', error, info);
+  };
+
+  const handleReset = (): void => {
+    window.location.reload();
+  };
+
+  return (
+    <ErrorBoundary fallback={<ErrorPage />} onError={handleError} onReset={handleReset}>
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/client/src/pages/error.tsx
+++ b/client/src/pages/error.tsx
@@ -1,0 +1,20 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { AlertTriangle } from "lucide-react";
+
+export default function ErrorPage() {
+  return (
+    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
+      <Card className="w-full max-w-md mx-4">
+        <CardContent className="pt-6">
+          <div className="flex mb-4 gap-2">
+            <AlertTriangle className="h-8 w-8 text-red-500" />
+            <h1 className="text-2xl font-bold text-gray-900">Something went wrong</h1>
+          </div>
+          <p className="mt-2 text-sm text-gray-600">
+            We encountered an unexpected error. Please try refreshing the page or contact support if the problem persists.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a `GlobalErrorBoundary` wrapper component
- render a friendly `ErrorPage` fallback
- integrate the global boundary into `App`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run check` *(fails: Type errors in broken files)*