### PR TITLE
[client/dashboard] add quick start help modal

### DIFF
--- a/client/src/components/student/quick-start-dialog.tsx
+++ b/client/src/components/student/quick-start-dialog.tsx
@@ -1,0 +1,36 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+export function QuickStartDialog() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="secondary" size="sm">
+          Quick Start
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Getting Started</DialogTitle>
+          <DialogDescription>
+            Learn the basics of submitting work and viewing AI feedback.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2 text-sm">
+          <p><strong>1.</strong> Browse available assignments from the Assignments page.</p>
+          <p><strong>2.</strong> Submit your work to receive instant AI-powered feedback.</p>
+          <p><strong>3.</strong> Review feedback anytime in your Submission History.</p>
+          <p>
+            For more details, see our{' '}
+            <a href="/documentation" className="text-primary hover:underline">documentation</a>{' '}
+            or visit the{' '}
+            <a href="/help" className="text-primary hover:underline">help center</a>.
+          </p>
+        </div>
+        <DialogFooter className="pt-4">
+          <Button variant="outline">Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -11,6 +11,7 @@ import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { ClipboardList, BookOpen } from "lucide-react";
+import { QuickStartDialog } from "@/components/student/quick-start-dialog";
 
 export default function Dashboard() {
   const { user } = useAuth();
@@ -36,9 +37,12 @@ export default function Dashboard() {
   return (
     <AppShell>
       <div className="max-w-6xl mx-auto">
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold text-neutral-800">Dashboard</h1>
-          <p className="text-neutral-600">Welcome back, {user.name}</p>
+        <div className="mb-6 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-neutral-800">Dashboard</h1>
+            <p className="text-neutral-600">Welcome back, {user.name}</p>
+          </div>
+          <QuickStartDialog />
         </div>
         
         <div className="mb-8">
@@ -109,7 +113,10 @@ export default function Dashboard() {
                 </div>
                 
                 <div className="border-t border-neutral-200 pt-5 text-sm text-neutral-500">
-                  <p>Need help? Check out our <span className="text-primary hover:underline cursor-pointer">quick start guide</span> or <span className="text-primary hover:underline cursor-pointer">contact support</span>.</p>
+                  <p>
+                    Need help? <QuickStartDialog /> or{' '}
+                    <span className="text-primary hover:underline cursor-pointer">contact support</span>.
+                  </p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add QuickStartDialog component with onboarding instructions
- link to this dialog from the dashboard header and empty state

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run check` *(fails: numerous existing type errors)*