### PR TITLE
[client/layout] hide MITNavbar for authenticated users

### DIFF
--- a/client/src/components/layout/mit-navbar.tsx
+++ b/client/src/components/layout/mit-navbar.tsx
@@ -18,6 +18,11 @@ export function MITNavbar() {
   const { user, isAuthenticated, logout } = useAuth();
   const [location] = useLocation();
 
+  // Logged in users use the in-app sidebar/header navigation
+  if (isAuthenticated) {
+    return null;
+  }
+
   // Navigation links based on user role
   const getNavLinks = () => {
     if (!isAuthenticated || !user) {


### PR DESCRIPTION
## Summary
- avoid UI duplication by not showing MITNavbar once logged in

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run check` *(fails to typecheck)*