### PR TITLE
[server/gemini] update default flash model to 05-20

### DIFF
--- a/client/src/pages/admin/system-config.tsx
+++ b/client/src/pages/admin/system-config.tsx
@@ -42,7 +42,7 @@ export default function SystemConfigPage() {
   const [aiSettings, setAiSettings] = useState({
     provider: "gemini",
     apiKey: "gem_••••••••••••••••••••••••",
-    model: "models/gemini-2.5-flash-preview-04-17", // Updated to use the newest Gemini model
+    model: "models/gemini-2.5-flash-preview-05-20", // Updated to use the newest Gemini model
     maxTokens: 4096,
     temperature: 0.7,
     enableContentFiltering: true,
@@ -425,7 +425,7 @@ export default function SystemConfigPage() {
                         </SelectTrigger>
                         <SelectContent>
                           {/* Gemini models */}
-                          <SelectItem value="models/gemini-2.5-flash-preview-04-17">Gemini 2.5 Flash (Preview)</SelectItem>
+                          <SelectItem value="models/gemini-2.5-flash-preview-05-20">Gemini 2.5 Flash (Preview)</SelectItem>
                           <SelectItem value="gemini-2.0-flash">Gemini 2.0 Flash</SelectItem>
                           {/* OpenAI models */}
                           <SelectItem value="gpt-4.1-mini-2025-04-14">GPT-4.1 Mini</SelectItem>
@@ -501,7 +501,7 @@ export default function SystemConfigPage() {
                     onClick={() => setAiSettings({
                       provider: "gemini", 
                       apiKey: "gem_••••••••••••••••••••••••",
-                      model: "models/gemini-2.5-flash-preview-04-17",
+                      model: "models/gemini-2.5-flash-preview-05-20",
                       maxTokens: 4096,
                       temperature: 0.7,
                       enableContentFiltering: true,

--- a/server/adapters/gemini-adapter.ts
+++ b/server/adapters/gemini-adapter.ts
@@ -27,7 +27,7 @@ interface GeminiFilePart {
 const BASE_MAX_TOKENS = 1200;   // first attempt
 const RETRY_MAX_TOKENS = 1600;  // if finishReason !== "STOP"
 
-// The newest Gemini model is "gemini-2.5-flash-preview-04-17" which was released April 17, 2025
+// The newest Gemini model is "gemini-2.5-flash-preview-05-20" which was released May 20, 2025
 import { ContentType } from '../utils/file-type-settings';
 import { AIAdapter, AIAdapterResponse, MultimodalPromptPart } from './interfaces';
 import { CriteriaScore } from '@shared/schema';
@@ -262,7 +262,7 @@ export class GeminiAdapter implements AIAdapter {
     this.genAI = new GoogleGenAI({ apiKey });
     
     // Make model name configurable with environment variable or use default
-    this.modelName = process.env.GEMINI_MODEL_NAME ?? "gemini-2.5-flash-preview-04-17";
+    this.modelName = process.env.GEMINI_MODEL_NAME ?? "gemini-2.5-flash-preview-05-20";
     
     console.log(`[GEMINI] Initializing with model: ${this.modelName}`);
     

--- a/server/docs/AI_MODELS.md
+++ b/server/docs/AI_MODELS.md
@@ -8,7 +8,7 @@ This document outlines the AI models used in the AI Feedback Platform and how to
 
 The platform is configured to prioritize Google Gemini over other AI providers. 
 
-- **Default Model**: `models/gemini-2.5-flash-preview-04-17`
+- **Default Model**: `models/gemini-2.5-flash-preview-05-20`
 - **Alternate Model**: `gemini-2.0-flash`
 
 ### OpenAI (Fallback Provider)

--- a/server/queue/bullmq-submission-queue.ts
+++ b/server/queue/bullmq-submission-queue.ts
@@ -96,7 +96,7 @@ function createAIService() {
   if (process.env.GEMINI_API_KEY) {
     logger.info('AI adapter selected', { 
       adapter: 'Gemini',
-      model: 'models/gemini-2.5-flash-preview-04-17'
+      model: 'models/gemini-2.5-flash-preview-05-20'
     });
     aiAdapter = new GeminiAdapter();
   } 


### PR DESCRIPTION
## Summary
- bump the default Gemini Flash model to `gemini-2.5-flash-preview-05-20`
- update queue logs and admin config selections
- document the new default model in `AI_MODELS.md`

Consulted `docs/gemini_references/index.md` for API reference.

## Testing
- `npx vitest run` *(fails: connect EHOSTUNREACH)*
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run check` *(fails with TypeScript errors)*