### PR TITLE
[client/nav] streamline dashboard navigation

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -57,6 +57,13 @@ The application has different interfaces for different user roles:
 - **Instructor Interface**: Create assignments, review submissions, view analytics
 - **Admin Interface**: Manage users, monitor system health, configure settings
 
+## Navigation Layout
+
+Unauthenticated pages (such as the login screen or public submission links)
+display the `MITNavbar` at the top. Once a user is signed in, the interface
+switches to a dashboard layout that provides a sidebar and compact header for
+navigation. The top navbar is hidden in this mode to avoid duplicate menus.
+
 ## Important Directories
 
 ### Components

--- a/client/src/components/layout/mit-navbar.tsx
+++ b/client/src/components/layout/mit-navbar.tsx
@@ -18,6 +18,12 @@ export function MITNavbar() {
   const { user, isAuthenticated, logout } = useAuth();
   const [location] = useLocation();
 
+  // Authenticated pages use their own dashboard layout with a sidebar
+  // and header. Hide this top navigation bar to prevent redundancy.
+  if (isAuthenticated) {
+    return null;
+  }
+
   // Navigation links based on user role
   const getNavLinks = () => {
     if (!isAuthenticated || !user) {


### PR DESCRIPTION
## Summary
- hide MITNavbar when user is authenticated to avoid duplicate navigation
- document new behaviour in `client/README.md`

## Testing
- `npm run check` *(fails: TS errors in broken files)*
- `./run-tests.sh` *(fails: network access required)*